### PR TITLE
docs: add product vision and roadmap from competitive analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,153 @@
+# Ridecast2: Product Roadmap
+
+Priorities derived from competitive analysis (March 2026) against NotebookLM, Speechify, ElevenReader, NaturalReader, Listening.io, and Pocket. See [VISION.md](VISION.md) for positioning context.
+
+## How to Read This
+
+- **Phase 1** = table stakes. The product doesn't deliver on its promise without these.
+- **Phase 2** = competitive differentiation. These create distance from NotebookLM and TTS readers.
+- **Phase 3** = moat builders. These make the product defensible long-term.
+- **Won't Do** = conscious exclusions based on competitive positioning.
+
+Each item links to its GitHub issue for tracking.
+
+---
+
+## Phase 1: "It Actually Works" (Table Stakes)
+
+*These aren't features — they're the gap between "demo" and "daily driver."*
+
+### 1.1 Duration Accuracy — [#5](https://github.com/cpark4x/ridecast2/issues/5)
+**Priority: Critical** | Label: `P0`
+
+Duration control is the core differentiator (see VISION.md). A 15-minute target that produces 4 minutes or 20 minutes breaks the fundamental promise. The prompt was improved in PR #2 but still overshoots on long content.
+
+Options to explore:
+- Post-generation word count validation with retry loop
+- Tighter prompt constraints (word count floor/ceiling, not just target)
+- Two-pass: generate long, then trim to target
+
+### 1.2 Upload Screen Reset — [#4](https://github.com/cpark4x/ridecast2/issues/4)
+**Priority: High** | Label: `P0`
+
+After generating audio, the upload screen still shows the previous content's preview. Users must reload the page to start fresh. Basic UX bug that breaks the "process another" flow.
+
+### 1.3 Pipeline Error Resilience — [#3](https://github.com/cpark4x/ridecast2/issues/3)
+**Priority: High** | Label: `P0`
+
+PR #2 fixed several crashers (JSON fences, TTS token limits, duplicate content blocking), but the pipeline needs to handle any content gracefully:
+- Extremely long documents (200K+ tokens)
+- Malformed PDFs / protected EPUBs
+- Rate limits from Claude or OpenAI
+- Network interruptions mid-generation
+- Timeouts on slow content extraction
+
+The goal: no user-facing crash, ever. Fail with actionable messages.
+
+---
+
+## Phase 2: Competitive Differentiation
+
+*These close the gap with NotebookLM and create distance from TTS readers.*
+
+### 2.1 Native Mobile App — [#6](https://github.com/cpark4x/ridecast2/issues/6)
+**Priority: High** | Label: `P1` | Effort: Large
+
+The single biggest gap. Ridecast2 is a commute product without a real mobile app. The PWA works technically but:
+- Not discoverable (no App Store presence)
+- Can't do reliable background audio on iOS
+- No push notifications for "your episode is ready"
+- Loses to native apps on perceived quality
+
+React Native or Expo recommended — share business logic with the Next.js backend, native player experience on the front.
+
+### 2.2 Better Voices (ElevenLabs Integration) — [#9](https://github.com/cpark4x/ridecast2/issues/9)
+**Priority: Medium** | Label: `P1` | Effort: Medium
+
+OpenAI's TTS is good but ElevenLabs' voices are noticeably more natural. Voice quality is visceral — users judge audio products in 3 seconds.
+
+Approach: Add ElevenLabs as an optional TTS provider (BYOK — user provides their own API key). The provider interface in `src/lib/tts/` already abstracts the TTS service, so this should be a clean addition.
+
+### 2.3 Browser Extension — [#8](https://github.com/cpark4x/ridecast2/issues/8)
+**Priority: Medium** | Label: `P1` | Effort: Medium
+
+"Right-click any article > Send to Ridecast." This is how Speechify and ElevenReader acquire daily-use habit. Low-friction content capture that keeps users in their browsing flow.
+
+Chrome extension that sends the current page URL to the Ridecast2 instance for processing. Minimal UI — just the duration picker and a "Process" button.
+
+### 2.4 Episode Versioning — [#7](https://github.com/cpark4x/ridecast2/issues/7)
+**Priority: Medium** | Label: `P1` | Effort: Small
+
+Currently, re-processing content with different settings overwrites the previous version. The library shows only the latest script/audio per content item.
+
+Users should be able to have a 5-minute quick summary AND a 30-minute deep dive from the same source. The data model already links scripts to content — this is primarily a UI change to show multiple versions.
+
+---
+
+## Phase 3: Moat Builders
+
+*These make the product defensible and create switching costs.*
+
+### 3.1 Multi-Source Synthesis — [#12](https://github.com/cpark4x/ridecast2/issues/12)
+**Priority: Medium** | Label: `P2` | Effort: Large
+
+NotebookLM's killer feature: combine multiple documents into one conversation. "Give me a 20-minute episode covering these 3 articles about the same topic."
+
+This is technically complex (multi-document summarization with coherent narrative) but is a genuine moat feature. NotebookLM supports up to 50 sources per notebook.
+
+### 3.2 Episode Sharing — [#10](https://github.com/cpark4x/ridecast2/issues/10)
+**Priority: Low** | Label: `P2` | Effort: Medium
+
+Share a generated episode as a link. NotebookLM recently added audio sharing. This creates a viral loop — someone hears a Ridecast2 episode and wants to make their own.
+
+Requires: hosted audio storage (currently local filesystem), shareable URLs, basic playback page.
+
+### 3.3 Scheduled Production — [#13](https://github.com/cpark4x/ridecast2/issues/13)
+**Priority: Low** | Label: `P2` | Effort: Large
+
+Connect an RSS feed or newsletter > auto-generate episodes every morning for your commute. The "set it and forget it" version of Listening.io's model, but with actual AI compression.
+
+This is the long-term daily-habit play: wake up, commute episodes are already waiting.
+
+### 3.4 Voice Selection — [#11](https://github.com/cpark4x/ridecast2/issues/11)
+**Priority: Low** | Label: `P2` | Effort: Small-Medium
+
+Offer 3-5 narrator voices and let users pick their preferred voice. Not 1,000 voices (can't compete with Speechify) — just enough for personalization. Retention driver.
+
+Depends on 2.2 (ElevenLabs integration) for the best voice options.
+
+---
+
+## Won't Do
+
+These are conscious positioning decisions, not "someday" items:
+
+| Item | Reason |
+|------|--------|
+| Massive voice library (100+) | Can't out-voice Speechify/ElevenLabs. Focus on production quality. |
+| OCR / camera scanning | Different use case (physical books). Stay digital-first. |
+| Real-time text highlighting | TTS reader feature. We produce episodes, not read-alongs. |
+| Enterprise / accessibility | Speechify owns this market. Don't dilute positioning. |
+
+---
+
+## Current Status (March 2026)
+
+### Shipped (PR #2, merged to main)
+- 5/5 E2E tests passing
+- Claude JSON parsing fix
+- Infinite loading screen fix (error UI + retry)
+- Library refresh on tab switch
+- React Strict Mode double-mount fix
+- Large file handling (truncation + error messages)
+- Duration prompt improvement (floor/ceiling)
+- Duplicate content handling (return existing)
+- TTS script chunking for long content
+- Specific error messages throughout pipeline
+
+### Next Up
+Phase 1 items, in order: duration accuracy > upload reset > pipeline resilience.
+
+---
+
+*Last updated: 2026-03-06. Roadmap is informed by competitive positioning — see VISION.md.*

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,103 @@
+# Ridecast2: Product Vision
+
+> **Turn anything into a podcast that fits your commute.**
+
+## What Ridecast2 Is
+
+Ridecast2 is a **Personal Podcast Producer**. You give it content — a PDF, an article, a book chapter — and it produces a compressed, formatted audio episode tailored to your available time. It doesn't read your content aloud. It *produces a show* from it.
+
+The AI summarization engine is the heart. TTS is the delivery mechanism. The target duration is the constraint that makes it useful.
+
+## The Insight
+
+The content-to-audio market has three categories competing for the same user need ("I have text, I want audio"):
+
+1. **AI Podcast Generators** — Transform content into conversational, produced audio (NotebookLM, Ridecast2)
+2. **TTS Reader Apps** — Read text aloud with high-quality voices (Speechify, ElevenReader, NaturalReader)
+3. **Article-to-Podcast Pipes** — Convert saved articles into podcast feeds (Listening.io)
+
+These are fundamentally different products despite the surface similarity. Category 2 is a bloodbath — Speechify has 276K five-star reviews, an Apple Design Award, and 1,000+ voices. ElevenLabs has the best synthetic voices in the industry. You can't win that fight as an indie product.
+
+Category 1 has exactly one competitor: **Google NotebookLM**. It's free, backed by Google, and produces incredible audio. But it's a research tool that happens to make audio — not an audio-first product. No mobile app. No duration control. No offline. No commute UX.
+
+**The gap between "research tool that makes audio" and "commute audio app" is Ridecast2's entire opportunity.**
+
+## Three Pillars
+
+### 1. Duration-First
+
+You pick the time, AI fills it. "I have 15 minutes — make me an episode." No one else does this. NotebookLM gives you what it gives you. Speechify reads the whole thing. Ridecast2 shapes content to your time.
+
+### 2. Commute-Optimized
+
+Car mode. Speed controls. Offline playback. Library management. Skip buttons. Bottom-nav player. This is built for the car, train, and bus — not for sitting at a desk.
+
+### 3. Format Intelligence
+
+AI chooses narrator vs. conversation based on content type. Dense analytical content becomes a two-host discussion (makes it digestible). Narrative content gets a clean narrator delivery. Not just TTS — production.
+
+## Competitive Position
+
+| Capability | Ridecast2 | NotebookLM | Speechify | ElevenReader |
+|---|---|---|---|---|
+| AI summarization/compression | Yes | Yes | No (verbatim) | No (verbatim) |
+| Duration control | 5-60 min slider | No (format-based) | N/A | N/A |
+| Conversation format | Narrator or conversation | Two-host only | Single voice | Single voice |
+| Mobile app | PWA | Web only | Native | Native |
+| Offline listening | Yes (IndexedDB) | No | Yes | Yes |
+| Car mode | Yes | No | No | No |
+| Voice quality | Good (OpenAI TTS) | Excellent (Gemini) | Excellent (premium) | Best (ElevenLabs) |
+| Price | Free (self-hosted, BYOK) | Free | $29/mo | $11/mo |
+
+## Strengths
+
+- **Duration control is genuinely unique.** No competitor lets you say "give me a 15-minute version of this book."
+- **Commute-first UX is differentiated.** Car mode, speed controls, player — designed for listening on the go.
+- **Format choice is smart.** Narrator vs. conversation, chosen by AI based on content type.
+- **Self-hosted / privacy.** Content stays on your machine. No cloud uploads.
+- **The pipeline works.** End-to-end — upload, process, play, real audio, real quality.
+
+## Vulnerabilities
+
+- **NotebookLM is free and Google-backed.** If they add duration control and a mobile app, positioning narrows significantly.
+- **Voice quality is "good enough" but not best-in-class.** Users judge audio products in 3 seconds of listening.
+- **No native mobile app for a commute product is a contradiction.** PWA works technically but isn't discoverable and can't do reliable background audio.
+- **Duration accuracy is unreliable.** The core promise needs to consistently deliver.
+
+## The Biggest Risk
+
+Google adds a "Duration" slider and a mobile app to NotebookLM. That collapses the positioning gap.
+
+The defense: be **faster, more opinionated, and more commute-specific** than Google's research-tool-that-also-does-audio approach. Own the commute use case so thoroughly that even if NotebookLM adds duration control, users still prefer Ridecast2 for the listening experience.
+
+## Market Opportunities
+
+1. **Pocket is dead.** Mozilla is discontinuing Pocket. Millions of read-it-later users need a new home. ElevenReader is positioning for this — but they read verbatim. Ridecast2 offers *summarized* audio.
+
+2. **NotebookLM's gaps are our strengths.** No mobile app, no duration control, no commute UX, no offline. Users who love the audio quality but want it for their commute are underserved.
+
+3. **Price gap.** Speechify at $29/mo and ElevenReader at $11/mo leave room. Ridecast2 is free (self-hosted, user provides API keys) — compelling for technical users. A hosted version could undercut both.
+
+4. **The "AI podcast" category is nascent.** Most competitors are TTS readers, not content producers. The gap between "read this aloud" and "produce a podcast episode from this" is the entire value proposition.
+
+## What We Don't Do
+
+These are conscious choices, not gaps:
+
+- **Massive voice library** — Can't out-voice Speechify (1,000+ voices) or ElevenLabs. Offer 3-5 good voices, focus on production quality.
+- **OCR / camera scanning** — Speechify's OCR for physical books is a different use case. Stay digital-first.
+- **Real-time text highlighting** — That's a TTS reader feature. We produce episodes, we don't read along.
+- **Enterprise / accessibility positioning** — Speechify owns the dyslexia/ADHD/accessibility market. Don't compete there.
+
+## Success Metrics
+
+The product succeeds when:
+
+1. **Duration accuracy is reliable** — A 15-minute target produces 13-17 minutes of audio consistently
+2. **Daily commute usage** — Users process content in the evening, listen during their commute
+3. **Content variety** — Works well across articles, book chapters, PDFs, and meeting notes
+4. **Repeat usage** — Users come back because the audio quality and compression are worth the processing time
+
+---
+
+*Last updated: 2026-03-06. Based on competitive analysis conducted across NotebookLM, Speechify, ElevenReader, NaturalReader, Listening.io, and Pocket.*


### PR DESCRIPTION
## Summary
- Add **VISION.md** — product vision and competitive positioning
- Add **ROADMAP.md** — tiered product roadmap with linked GitHub issues

These are foundational product strategy documents derived from competitive analysis.

## Test plan
- [x] Docs-only change — no code impact
- [ ] Verify rendered Markdown on GitHub

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)