### PR TITLE
fix: duration accuracy - word count validation with retry

### DIFF
--- a/src/app/api/audio/generate/route.ts
+++ b/src/app/api/audio/generate/route.ts
@@ -6,8 +6,7 @@ import { prisma } from '@/lib/db';
 import { OpenAITTSProvider } from '@/lib/tts/openai';
 import { generateNarratorAudio } from '@/lib/tts/narrator';
 import { generateConversationAudio } from '@/lib/tts/conversation';
-
-const WORDS_PER_MINUTE = 150;
+import { WORDS_PER_MINUTE } from '@/lib/utils/duration';
 
 export async function POST(request: Request) {
   try {
@@ -69,6 +68,16 @@ export async function POST(request: Request) {
     const wordCount = script.scriptText.split(/\s+/).length;
     const durationFromWords = (wordCount / WORDS_PER_MINUTE) * 60;
     const durationSecs = durationFromFile > 10 ? Math.round(durationFromFile) : Math.round(durationFromWords);
+
+    // Log duration accuracy for calibration
+    const targetSecs = script.targetDuration * 60;
+    const deltaSecs = durationSecs - targetSecs;
+    const deltaPct = Math.round((deltaSecs / targetSecs) * 100);
+    console.log(
+      `[duration] Audio generated: ${durationSecs}s actual vs ${targetSecs}s target ` +
+      `(${deltaSecs > 0 ? '+' : ''}${deltaSecs}s / ${deltaPct > 0 ? '+' : ''}${deltaPct}%). ` +
+      `Script: ${wordCount} words at ${WORDS_PER_MINUTE} WPM assumption.`
+    );
 
     // Create Audio record in DB
     const audio = await prisma.audio.create({

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -1,8 +1,8 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { AIProvider, ContentAnalysis, ScriptConfig, GeneratedScript } from './types';
+import { WORDS_PER_MINUTE } from '@/lib/utils/duration';
 
 const MODEL = 'claude-sonnet-4-20250514';
-const WORDS_PER_MINUTE = 150;
 const ANALYSIS_MAX_TOKENS = 1024;
 const MAX_ANALYSIS_CHARS = 3000;
 // Claude's context window is 200K tokens (~800K chars). Reserve space for
@@ -88,6 +88,8 @@ ${truncated}`,
 
   async generateScript(text: string, config: ScriptConfig): Promise<GeneratedScript> {
     const targetWords = config.targetMinutes * WORDS_PER_MINUTE;
+    const minWords = Math.round(targetWords * 0.7);
+    const maxWords = Math.round(targetWords * 1.3);
 
     // Truncate to stay within Claude's context window. For very large
     // documents the beginning is usually enough for a good summary.
@@ -95,11 +97,60 @@ ${truncated}`,
       ? text.slice(0, MAX_SCRIPT_SOURCE_CHARS) + '\n\n[Content truncated for length]'
       : text;
 
-    const prompt =
-      config.format === 'narrator'
-        ? `Create a spoken-word podcast script summarizing the following content.
+    const prompt = this.buildScriptPrompt(config, targetWords, sourceText);
 
-Length: The listener expects about ${config.targetMinutes} minutes of audio. At 150 words per minute, aim for around ${targetWords} words. It's fine to be somewhat over or under, but don't be dramatically shorter — a 4-minute script for a 15-minute target leaves the listener with nothing for most of their commute. Develop ideas fully, use examples, and give key points room to breathe.
+    let result = await this.callGenerateScript(prompt, targetWords);
+
+    // Validate word count. If outside ±30% tolerance, retry once with
+    // explicit correction. One retry only — LLMs are stochastic.
+    if (result.wordCount < minWords || result.wordCount > maxWords) {
+      const direction = result.wordCount < minWords ? 'short' : 'long';
+      const guidance = direction === 'short'
+        ? 'Expand ideas further, add more examples, and develop each point in greater depth.'
+        : 'Compress more aggressively. Focus only on the most important points and cut secondary details.';
+
+      console.log(
+        `[duration] Script ${direction}: ${result.wordCount} words vs ${targetWords} target ` +
+        `(${config.targetMinutes} min). Retrying with correction.`
+      );
+
+      const correctionPrompt = `${prompt}
+
+IMPORTANT CORRECTION: Your script must be between ${minWords} and ${maxWords} words. The target is ${targetWords} words (${config.targetMinutes} minutes at ${WORDS_PER_MINUTE} words per minute). ${guidance}`;
+
+      result = await this.callGenerateScript(correctionPrompt, targetWords);
+
+      if (result.wordCount < minWords || result.wordCount > maxWords) {
+        console.warn(
+          `[duration] Script still ${result.wordCount < minWords ? 'short' : 'long'} after retry: ` +
+          `${result.wordCount} words vs ${targetWords} target. Proceeding with best effort.`
+        );
+      } else {
+        console.log(
+          `[duration] Retry succeeded: ${result.wordCount} words (target: ${targetWords}).`
+        );
+      }
+    }
+
+    return {
+      text: result.text,
+      wordCount: result.wordCount,
+      format: config.format,
+    };
+  }
+
+  private buildScriptPrompt(
+    config: ScriptConfig,
+    targetWords: number,
+    sourceText: string,
+  ): string {
+    const minWords = Math.round(targetWords * 0.7);
+    const maxWords = Math.round(targetWords * 1.3);
+
+    return config.format === 'narrator'
+      ? `Create a spoken-word podcast script summarizing the following content.
+
+Length: The listener expects about ${config.targetMinutes} minutes of audio. At ${WORDS_PER_MINUTE} words per minute, write between ${minWords} and ${maxWords} words (target: ${targetWords}). Don't be dramatically shorter — a 4-minute script for a 15-minute target leaves the listener with nothing for most of their commute. Develop ideas fully, use examples, and give key points room to breathe.
 
 Style:
 - Natural, engaging narrator voice
@@ -109,9 +160,9 @@ Style:
 
 Source text:
 ${sourceText}`
-        : `Create a two-speaker podcast conversation script about the following content.
+      : `Create a two-speaker podcast conversation script about the following content.
 
-Length: The listener expects about ${config.targetMinutes} minutes of audio. At 150 words per minute, aim for around ${targetWords} words. It's fine to be somewhat over or under, but don't be dramatically shorter — a 4-minute script for a 15-minute target leaves the listener with nothing for most of their commute. Let the conversation develop naturally, explore tangents, and give ideas room to breathe.
+Length: The listener expects about ${config.targetMinutes} minutes of audio. At ${WORDS_PER_MINUTE} words per minute, write between ${minWords} and ${maxWords} words (target: ${targetWords}). Don't be dramatically shorter — a 4-minute script for a 15-minute target leaves the listener with nothing for most of their commute. Let the conversation develop naturally, explore tangents, and give ideas room to breathe.
 
 Style:
 - Use exactly two speakers labeled [Host A] and [Host B]
@@ -122,7 +173,12 @@ Style:
 
 Source text:
 ${sourceText}`;
+  }
 
+  private async callGenerateScript(
+    prompt: string,
+    targetWords: number,
+  ): Promise<{ text: string; wordCount: number }> {
     const response = await this.client.messages.create({
       model: MODEL,
       max_tokens: targetWords * 2,
@@ -139,13 +195,9 @@ ${sourceText}`;
       throw new Error('Unexpected response type from Claude');
     }
 
-    const scriptText = content.text.trim();
-    const wordCount = scriptText.split(/\s+/).filter(Boolean).length;
+    const text = content.text.trim();
+    const wordCount = text.split(/\s+/).filter(Boolean).length;
 
-    return {
-      text: scriptText,
-      wordCount,
-      format: config.format,
-    };
+    return { text, wordCount };
   }
 }

--- a/src/lib/utils/duration.ts
+++ b/src/lib/utils/duration.ts
@@ -1,4 +1,4 @@
-const WORDS_PER_MINUTE = 150;
+export const WORDS_PER_MINUTE = 150;
 
 export function minutesToWords(minutes: number): number {
   return minutes * WORDS_PER_MINUTE;


### PR DESCRIPTION
## Summary

Duration control is RideCast's core differentiator — podcasts that match your commute — but generated scripts frequently overshoot or undershoot the target duration. This PR adds word count validation with a retry loop to bring duration accuracy within a reliable tolerance band.

## What changed

**3 files modified** (78 insertions, 17 deletions):

- **`src/lib/utils/duration.ts`** — Exported `WORDS_PER_MINUTE` as the single source of truth (was duplicated across files)
- **`src/lib/ai/claude.ts`** — Added word count validation against a ±30% tolerance band after script generation, with one retry using an explicit correction prompt. Refactored prompt builder to specify a word count *range* rather than a single target.
- **`src/app/api/audio/generate/route.ts`** — Imported the shared `WORDS_PER_MINUTE` constant and added duration delta logging for ongoing calibration.

## How it works

1. After Claude generates a script, we count the words and compute expected duration using `WORDS_PER_MINUTE`.
2. If the result falls outside a **±30% tolerance band** of the requested duration, we retry **once** with a correction prompt that tells Claude the exact word count needed.
3. If the retry still misses, we proceed best-effort (no infinite loops, no user-facing error).
4. Duration delta (requested vs. estimated) is logged on every generation for future calibration.

## Test plan

- [x] 5/5 E2E tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Manual smoke test: 5-min, 15-min, and 30-min generations all land within tolerance

Closes #5

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)